### PR TITLE
Fixed session store flag behavior

### DIFF
--- a/TestDailymotion.py
+++ b/TestDailymotion.py
@@ -100,3 +100,12 @@ class TestA(unittest.TestCase):
                         })
     
 
+    def test_session_store_option(self):
+        d = dailymotion.Dailymotion(session_store_enabled=False)
+        self.assertFalse(d._session_store_enabled)
+
+        d = dailymotion.Dailymotion(session_store_enabled=True)
+        self.assertTrue(d._session_store_enabled)
+
+        d = dailymotion.Dailymotion(session_store_enabled=None)
+        self.assertEqual(d.DEFAULT_SESSION_STORE, d._session_store_enabled)

--- a/dailymotion.py
+++ b/dailymotion.py
@@ -99,7 +99,7 @@ class Dailymotion(object):
         self._grant_info                    = {}
         self._headers                       = {'Accept' : 'application/json',
                                                 'User-Agent' : 'Dailymotion-Python/%s (Python %s)' % (__version__, __python_version__)}
-        self._session_store_enabled         = session_store_enabled or self.DEFAULT_SESSION_STORE
+        self._session_store_enabled         = session_store_enabled if session_store_enabled is not None else self.DEFAULT_SESSION_STORE
         self._session_store                 = None
         
 


### PR DESCRIPTION
The current logic for the session store feature toggle is not working properly. Trying to disable the session store with `session_store_enabled=False` will always fall into the default value (which is `True`) since the inline `or` will not differentiate a `None` from `False`.

This PR fixes that behavior.
